### PR TITLE
Fixes GHC Option

### DIFF
--- a/cabal-macOS.project
+++ b/cabal-macOS.project
@@ -1,6 +1,7 @@
 import: cabal.project.freeze
 packages: .
 executable-static: False
+optimization: True
 shared: True
 static: False
 allow-newer: stack:Cabal, validation-selective:selective

--- a/cabal-ubuntu.project
+++ b/cabal-ubuntu.project
@@ -2,6 +2,7 @@ import: cabal.project.freeze
 packages: .
 static: True
 executable-static: True
+optimization: True
 shared: True
 executable-dynamic: False
 allow-newer: stack:Cabal, validation-selective:selective

--- a/guardian.cabal
+++ b/guardian.cabal
@@ -83,7 +83,7 @@ executable guardian
       Paths_guardian
   hs-source-dirs:
       app
-  ghc-options: -Wall -O
+  ghc-options: -Wall
   build-depends:
       base >=4.7 && <5
     , guardian
@@ -104,7 +104,7 @@ test-suite guardian-test
       Paths_guardian
   hs-source-dirs:
       test
-  ghc-options: -Wall -O
+  ghc-options: -Wall
   build-tool-depends:
       tasty-discover:tasty-discover
   build-depends:

--- a/package.yaml
+++ b/package.yaml
@@ -63,8 +63,6 @@ tests:
   guardian-test:
     main: Spec.hs
     source-dirs: test
-    ghc-options:
-    - -O
     build-tools:
     - tasty-discover
     dependencies:
@@ -85,7 +83,5 @@ executables:
   guardian:
     source-dirs: app
     main: Main.hs
-    ghc-options:
-    - -O
     dependencies:
     - guardian


### PR DESCRIPTION
Hackage rejected upload because of `ghc-options: -O`. This PR removes the options.