### PR TITLE
CI: bumps up `actions/*-artifacts` to v4

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -180,6 +180,7 @@ jobs:
         cabal install graphmod
         mkdir -p ~/.local/bin
         echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+        echo "${HOME}/.ghcup/bin" >> "${GITHUB_PATH}"
     - name: Intall cabal-plan (Linux)
       if: ${{ matrix.os == 'ubuntu' }}
       run: |

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -182,14 +182,6 @@ jobs:
         mkdir -p ~/.local/bin
         echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
         echo "${HOME}/.ghcup/bin" >> "${GITHUB_PATH}"
-    - name: Inspect environments (macOS)
-      if: ${{ matrix.os == 'macOS' }}
-      run: |
-        echo "PATH=${PATH}"
-        ls -R "${HOME}/.ghcup"
-        ls -R "${HOME}/.local"
-        which stack
-        stack --version
     - name: Intall cabal-plan (Linux)
       if: ${{ matrix.os == 'ubuntu' }}
       run: |

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -134,7 +134,7 @@ jobs:
           echo "COPYING: $(basename "${FILE}") (${FILE})"
           cp "${FILE}" "${{env.bin-artifacts}}/"
         done
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload Binary Artifacts
       with:
         name: bins-${{ runner.os }}
@@ -156,7 +156,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       id: download
       with:
         name: bins-${{ runner.os }}
@@ -219,7 +219,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Download Artifact(s)
       id: download
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: ${{ github.workspace }}/artifacts
     - name: Check Version

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -181,12 +181,17 @@ jobs:
         mkdir -p ~/.local/bin
         echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
         echo "${HOME}/.ghcup/bin" >> "${GITHUB_PATH}"
-    - name: Intall cabal-plan (Linux)
-      if: ${{ matrix.os == 'ubuntu' }}
+    - name: Inspect environments (macOS)
+      if: ${{ matrix.os == 'macOS' }}
       run: |
+        echo "PATH=${PATH}"
         ls -R "${HOME}/.ghcup"
         ls -R "${HOME}/.local"
         which stack
+        stack --version
+    - name: Intall cabal-plan (Linux)
+      if: ${{ matrix.os == 'ubuntu' }}
+      run: |
         curl --location 'https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz' | unxz > ~/.local/bin/cabal-plan
         chmod +x ~/.local/bin/cabal-plan
     - name: Run tests

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -173,7 +173,7 @@ jobs:
       with:
         ghc-version: 9.6.4
         cabal-version: 3.10.2.1
-        stack-version: 2.15.7
+        stack-version: 2.13.1
         enable-stack: true
     - run: cabal v2-update 'hackage.haskell.org,2023-02-13T02:00:06Z'
     - name: Installs test tool dependencies

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -174,6 +174,7 @@ jobs:
         ghc-version: 9.6.4
         cabal-version: 3.10.2.1
         stack-version: 2.15.7
+        enable-stack: true
     - run: cabal v2-update 'hackage.haskell.org,2023-02-13T02:00:06Z'
     - name: Installs test tool dependencies
       run: |
@@ -181,10 +182,9 @@ jobs:
         mkdir -p ~/.local/bin
         echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
         echo "${HOME}/.ghcup/bin" >> "${GITHUB_PATH}"
-    - name: Install Stack and Inspect environments (macOS)
+    - name: Inspect environments (macOS)
       if: ${{ matrix.os == 'macOS' }}
       run: |
-        ghcup install stack 2.15.7
         echo "PATH=${PATH}"
         ls -R "${HOME}/.ghcup"
         ls -R "${HOME}/.local"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -184,6 +184,9 @@ jobs:
     - name: Intall cabal-plan (Linux)
       if: ${{ matrix.os == 'ubuntu' }}
       run: |
+        ls -R "${HOME}/.ghcup"
+        ls -R "${HOME}/.local"
+        which stack
         curl --location 'https://github.com/haskell-hvr/cabal-plan/releases/download/v0.6.2.0/cabal-plan-0.6.2.0-x86_64-linux.xz' | unxz > ~/.local/bin/cabal-plan
         chmod +x ~/.local/bin/cabal-plan
     - name: Run tests

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -181,9 +181,10 @@ jobs:
         mkdir -p ~/.local/bin
         echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
         echo "${HOME}/.ghcup/bin" >> "${GITHUB_PATH}"
-    - name: Inspect environments (macOS)
+    - name: Install Stack and Inspect environments (macOS)
       if: ${{ matrix.os == 'macOS' }}
       run: |
+        ghcup install stack 2.15.7
         echo "PATH=${PATH}"
         ls -R "${HOME}/.ghcup"
         ls -R "${HOME}/.local"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -173,7 +173,7 @@ jobs:
       with:
         ghc-version: 9.6.4
         cabal-version: 3.10.2.1
-        stack-version: 2.9.3
+        stack-version: 2.15.7
     - run: cabal v2-update 'hackage.haskell.org,2023-02-13T02:00:06Z'
     - name: Installs test tool dependencies
       run: |

--- a/data/only-stack/dependency-domains-stack-dot.yaml
+++ b/data/only-stack/dependency-domains-stack-dot.yaml
@@ -20,4 +20,4 @@ components:
 
 custom:
   shell: |
-    stack dot --no-external --no-include-base 2>/dev/null
+    stack dot --no-external --no-include-base


### PR DESCRIPTION
This is a asecurity fix for https://github.com/advisories/GHSA-6q32-hq47-5qq3.