### PR TITLE
Support Cabal-3.16

### DIFF
--- a/src/Development/Guardian/Graph/Adapter/Cabal/Enabled.hs
+++ b/src/Development/Guardian/Graph/Adapter/Cabal/Enabled.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -32,7 +33,7 @@ import Distribution.Client.ProjectConfig (ProjectRoot (..))
 import Distribution.Client.ProjectOrchestration (CurrentCommand (..), ProjectBaseContext (..), establishProjectBaseContextWithRoot, withInstallPlan)
 import Distribution.Client.ProjectPlanning (ElaboratedConfiguredPackage (..), elabLocalToProject)
 import Distribution.Package (Package (..), packageName, unPackageName)
-import Distribution.Simple.Flag (Flag (..))
+import Distribution.Simple.Flag (pattern Flag)
 import Distribution.Verbosity (silent)
 import Path
 import RIO ((.~))


### PR DESCRIPTION
This is a backward-compatible patch to enable building of `guardian` with `Cabal-3.16`. See https://github.com/haskell/cabal/blob/master/release-notes/Cabal-3.16.0.0.md#migration-guide for context.

Supersedes #13.